### PR TITLE
PANDARIA: Fix the issue that preferences show other user's name

### DIFF
--- a/apis/management.cattle.io/v3/authn_types.go
+++ b/apis/management.cattle.io/v3/authn_types.go
@@ -39,7 +39,7 @@ type User struct {
 	Password           string     `json:"password,omitempty" norman:"writeOnly,noupdate"`
 	MustChangePassword bool       `json:"mustChangePassword,omitempty"`
 	PrincipalIDs       []string   `json:"principalIds,omitempty" norman:"type=array[reference[principal]]"`
-	Me                 bool       `json:"me,omitempty"`
+	Me                 bool       `json:"me,omitempty" norman:"nocreate,noupdate"`
 	Enabled            *bool      `json:"enabled,omitempty" norman:"default=true"`
 	Spec               UserSpec   `json:"spec,omitempty"`
 	Status             UserStatus `json:"status"`


### PR DESCRIPTION
Problem:

Preferences show other user's name and username instead of the logged in user

Solution:

Set `Me` field to nocreate and noupdate 

Related Issue:

https://github.com/cnrancher/pandaria/issues/659